### PR TITLE
Make script executable and globally accessible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,5 +29,5 @@ This repository is a Node.js CLI tool written in JavaScript.
 
 ## CLI Execution
 
-The main entry point for the CLI is `src/index.js`.
-The package is designed to be executable via `npx` or by installing it globally.
+The main entry point for the CLI is `bin/worker.js`.
+The package is designed to be executable via `npx` or by installing it globally using the command `mqtt-fs-worker`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The worker expects a shared volume to be mounted at a consistent path. In your d
 
 ```yaml
 services:
-  job-worker:
+  mqtt-fs-worker:
     image: node:20-slim
     restart: always
     volumes:
@@ -78,7 +78,7 @@ The worker can be configured via environment variables or command-line arguments
 
 ### Example usage:
 ```bash
-job-worker --url mqtt://broker:1883 --id worker-01 --topic custom/jobs
+mqtt-fs-worker --url mqtt://broker:1883 --id worker-01 --topic custom/jobs
 ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "mqtt": "^5.15.0"
       },
       "bin": {
-        "job-worker": "bin/worker.js"
+        "mqtt-fs-worker": "bin/worker.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "main": "src/index.js",
   "bin": {
-    "job-worker": "./bin/worker.js"
+    "mqtt-fs-worker": "./bin/worker.js"
   },
   "files": [
-    "src"
+    "src",
+    "bin"
   ],
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
This change configures the project to support global installation via `npm install -g`. The CLI command is renamed to `mqtt-fs-worker` and pointed to the correct entry point in `./bin/worker.js`. Documentation has been updated accordingly, and the `bin` directory is now included in the published package.

Fixes #10

---
*PR created automatically by Jules for task [13403395174612772684](https://jules.google.com/task/13403395174612772684) started by @boxheed*