### PR TITLE
Add Dry Run Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ The worker can be configured via environment variables or command-line arguments
 | `-u, --url` | `MQTT_URL` | `mqtt://localhost:1883` | MQTT Broker URL |
 | `-i, --id` | `WORKER_ID` | `worker-01` | Unique Worker ID (Client ID) |
 | `-t, --topic` | - | `jobs/pending` | Subscription topic |
+| `--dry-run` | - | - | Run in dry-run mode using local `test-payload.json` |
+
+### Dry Run Mode
+
+The Dry Run mode allows you to test the shell environment and file system permissions without an MQTT broker.
+When the `--dry-run` flag is used, the worker looks for a `test-payload.json` file in the current directory.
+
+`test-payload.json` example:
+```json
+{
+  "id": "dry-run-test",
+  "workDir": "./test-workdir",
+  "steps": [
+    "echo 'Testing environment'",
+    "ls -la"
+  ]
+}
+```
+
+Running dry run:
+```bash
+mqtt-fs-worker --dry-run
+```
 
 ### Example usage:
 ```bash

--- a/tasks/done/dry-run-mode.md
+++ b/tasks/done/dry-run-mode.md
@@ -1,0 +1,37 @@
+# Task: Dry Run Mode
+
+## Description
+
+Added a "Dry Run" mode to the CLI to allow testing the shell environment and file system permissions without requiring an MQTT broker.
+
+## Requirements
+
+- Add a `--dry-run` flag to the CLI.
+- If the flag is present:
+    - Look for a local `test-payload.json` file.
+    - Execute the steps defined in that file.
+    - Write to `job.log`.
+    - Print the result JSON to the console.
+- Update documentation.
+- Ensure unit tests pass.
+
+## Changes
+
+### `src/lib/executor.js`
+- Updated `executeJob` to support an optional `overrideConfig` parameter. If provided, it uses this configuration instead of reading `job.json` from the `workDir`.
+
+### `src/lib/worker.js`
+- Added `--dry-run` option using `commander`.
+- Implemented logic to read `test-payload.json` and call `executeJob` with the steps from the payload.
+- Added graceful handling and reporting of results to the console in dry-run mode.
+
+### `README.md`
+- Added a new section for "Dry Run Mode" explaining how to use it and providing an example `test-payload.json`.
+
+### `tests/dry-run.test.js`
+- Created a new test suite to verify the dry-run mode, including error handling for missing or invalid payload files.
+
+## Verification Results
+
+- All unit tests passed, including the new dry-run tests.
+- Verified that `executeJob` correctly handles both the traditional `job.json` approach and the new optional config approach.

--- a/tests/dry-run.test.js
+++ b/tests/dry-run.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { startWorker } from '../src/lib/worker.js';
+import * as executor from '../src/lib/executor.js';
+
+vi.mock('../src/lib/executor.js');
+vi.mock('node:fs');
+
+describe('Dry Run Mode', () => {
+  beforeEach(() => {
+    vi.spyOn(process, 'exit').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should execute job from test-payload.json when --dry-run is present', () => {
+    const mockPayload = {
+      id: 'test-dry-run',
+      workDir: './test-dir',
+      steps: ['echo hello']
+    };
+
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockPayload));
+    vi.mocked(executor.executeJob).mockReturnValue({ status: 'success', exitCode: 0 });
+
+    startWorker(['node', 'worker.js', '--dry-run']);
+
+    expect(fs.existsSync).toHaveBeenCalledWith(expect.stringContaining('test-payload.json'));
+    expect(executor.executeJob).toHaveBeenCalledWith('./test-dir', 'test-dry-run', { steps: ['echo hello'] });
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('"status": "success"'));
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('should use defaults if id and workDir are missing in test-payload.json', () => {
+    const mockPayload = {
+      steps: ['echo hello']
+    };
+
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockPayload));
+    vi.mocked(executor.executeJob).mockReturnValue({ status: 'success', exitCode: 0 });
+
+    startWorker(['node', 'worker.js', '--dry-run']);
+
+    expect(executor.executeJob).toHaveBeenCalledWith('.', 'dry-run', { steps: ['echo hello'] });
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('should exit with error if test-payload.json is missing', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    startWorker(['node', 'worker.js', '--dry-run']);
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('not found'));
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('should exit with error if test-payload.json is invalid JSON', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('invalid json');
+
+    startWorker(['node', 'worker.js', '--dry-run']);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse test-payload.json'),
+      expect.any(Error),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
This change adds a "Dry Run" mode to the `mqtt-fs-worker` CLI. This mode allows for testing the shell environment and file system permissions locally without needing an MQTT broker. 

Key changes:
- Refactored `executeJob` to accept an optional `overrideConfig` object.
- Added `--dry-run` flag to the worker CLI.
- Added logic to read and execute a job from `test-payload.json` when the flag is present.
- Updated documentation and added unit tests.

Fixes #13

---
*PR created automatically by Jules for task [12730406604287063947](https://jules.google.com/task/12730406604287063947) started by @boxheed*