### PR TITLE
Robust Process Signals

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
-import { startWorker } from '../src/lib/worker.js';
+import { startWorker, setupSignalHandlers } from '../src/lib/worker.js';
 
-startWorker();
+const client = startWorker();
+setupSignalHandlers(client);

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -98,3 +98,20 @@ export function startWorker(argv = process.argv) {
 
   return client;
 }
+
+/**
+ * Sets up signal handlers for graceful shutdown.
+ * @param {import('mqtt').MqttClient} client - The MQTT client instance.
+ */
+export function setupSignalHandlers(client) {
+  const handleSignal = (signal) => {
+    console.log(`Received ${signal}. Shutting down...`);
+    client.end(false, () => {
+      console.log('MQTT client disconnected. Exiting.');
+      process.exit(0);
+    });
+  };
+
+  process.on('SIGINT', () => handleSignal('SIGINT'));
+  process.on('SIGTERM', () => handleSignal('SIGTERM'));
+}


### PR DESCRIPTION
This change adds signal handlers for SIGINT and SIGTERM to the worker. When these signals are received, the worker logs the shutdown, gracefully disconnects from the MQTT broker, and then exits with code 0. This prevents "ghost" sessions on the MQTT broker when the worker is interrupted by the OS or Docker.

Fixes #12

---
*PR created automatically by Jules for task [3740726844761076535](https://jules.google.com/task/3740726844761076535) started by @boxheed*