### PR TITLE
Separate NATS request and response streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ After execution, the shared directory will contain a `results/` folder:
 | `-i, --id` | `WORKER_ID` | `worker-01` | Unique Worker ID (Durable) |
 | `-j, --jobs-dir` | `NATS_JOBS_DIR` | `./jobs` | Root for job sources (Shared) |
 | `-w, --workspaces-dir` | `NATS_WORKSPACES_DIR` | `./workspaces` | Root for execution (Local) |
-| `-s, --stream` | `NATS_STREAM` | `JOBS` | JetStream Stream Name |
+| `-s, --stream` | `NATS_STREAM` | `AGENT_JOBS` | JetStream Input Stream Name |
+| `-S, --output-stream` | `NATS_OUTPUT_STREAM` | `AGENT_RESULTS` | JetStream Output Stream Name |
 | `-k, --input-subject` | `NATS_INPUT_SUBJECT` | `jobs.pending` | NATS Subject to consume from |
 | `-r, --output-subject` | `NATS_OUTPUT_SUBJECT` | `jobs.results` | NATS Subject to publish results to |
 | `-v, --visibility-timeout` | `NATS_VISIBILITY_TIMEOUT` | `0` | Delay in seconds before publishing the result to NATS |
@@ -134,7 +135,7 @@ To scale workers, simply run multiple instances with the **same Durable Name** (
 
 Example:
 ```bash
-nats-fs-worker --id worker-pool --stream JOBS --input-subject jobs.pending
+nats-fs-worker --id worker-pool --stream AGENT_JOBS --input-subject jobs.pending
 ```
 
 ### Dry Run Mode

--- a/src/lib/executor.js
+++ b/src/lib/executor.js
@@ -150,20 +150,24 @@ export async function executeJob(
     // Wait for source directory to be visible (NFS eventual consistency)
     let attempts = 0;
     const { maxAttempts, delay } = retryConfig;
-    
+
     while (attempts < maxAttempts) {
-        if (fs.existsSync(sourceDir) && fs.readdirSync(sourceDir).length > 0) {
-            break;
-        }
-        attempts++;
-        if (attempts < maxAttempts) {
-            console.log(`Source directory ${sourceDir} not visible or empty. Retrying in ${delay}ms... (Attempt ${attempts}/${maxAttempts})`);
-            await new Promise(resolve => setTimeout(resolve, delay));
-        }
+      if (fs.existsSync(sourceDir) && fs.readdirSync(sourceDir).length > 0) {
+        break;
+      }
+      attempts++;
+      if (attempts < maxAttempts) {
+        console.log(
+          `Source directory ${sourceDir} not visible or empty. Retrying in ${delay}ms... (Attempt ${attempts}/${maxAttempts})`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
     }
 
     if (!fs.existsSync(sourceDir)) {
-      throw new Error(`Source directory ${sourceDir} not found after ${maxAttempts * delay}ms`);
+      throw new Error(
+        `Source directory ${sourceDir} not found after ${maxAttempts * delay}ms`,
+      );
     }
 
     // Ensure results directory exists

--- a/src/lib/hooks.js
+++ b/src/lib/hooks.js
@@ -13,7 +13,7 @@ export async function runHook(hooksDir, hookName, context) {
   if (!hooksDir) return;
 
   const hookPath = path.resolve(hooksDir, hookName);
-  
+
   // Check if hook exists and is executable
   if (!fs.existsSync(hookPath)) {
     return;

--- a/src/lib/sync.js
+++ b/src/lib/sync.js
@@ -41,7 +41,9 @@ function getFileStats(dir, exclude = []) {
           stats.set(relPath, s.size);
         } catch (statErr) {
           if (statErr.code === 'ENOENT') {
-            console.warn(`File ${fullPath} disappeared during sync validation, skipping.`);
+            console.warn(
+              `File ${fullPath} disappeared during sync validation, skipping.`,
+            );
           } else {
             throw statErr;
           }

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -71,8 +71,13 @@ export async function startWorker(argv = process.argv) {
     )
     .option(
       '-s, --stream <stream>',
-      'NATS JetStream Stream Name',
-      process.env.NATS_STREAM || 'JOBS',
+      'NATS JetStream Input Stream Name',
+      process.env.NATS_STREAM || 'AGENT_JOBS',
+    )
+    .option(
+      '-S, --output-stream <stream>',
+      'NATS JetStream Output Stream Name',
+      process.env.NATS_OUTPUT_STREAM || 'AGENT_RESULTS',
     )
     .option(
       '-k, --input-subject <subject>',
@@ -117,6 +122,7 @@ export async function startWorker(argv = process.argv) {
   const NATS_URL = options.url;
   const WORKER_ID = options.id;
   const STREAM = options.stream;
+  const OUTPUT_STREAM = options.outputStream;
   const SUBJECT = options.inputSubject;
     const OUTPUT_SUBJECT = options.outputSubject;
     const JOBS_DIR = options.jobsDir;
@@ -131,7 +137,8 @@ export async function startWorker(argv = process.argv) {
     if (HOOKS_DIR) {
       console.log(`Hooks directory: ${path.resolve(HOOKS_DIR)}`);
     }
-    console.log(`JetStream Stream: ${STREAM}, Subject: ${SUBJECT}`);
+    console.log(`JetStream Input Stream: ${STREAM}, Subject: ${SUBJECT}`);
+    console.log(`JetStream Output Stream: ${OUTPUT_STREAM}, Subject: ${OUTPUT_SUBJECT}`);
   if (VISIBILITY_TIMEOUT_MS > 0) {
     console.log(
       `Visibility timeout configured: ${VISIBILITY_TIMEOUT_MS / 1000}s`,
@@ -164,18 +171,27 @@ export async function startWorker(argv = process.argv) {
   try {
     const jsm = await nc.jetstreamManager();
 
-    // Ensure the stream exists
-    try {
-      await jsm.streams.info(STREAM);
-    } catch (err) {
-      if (err.message.includes('stream not found')) {
-        console.log(`Stream ${STREAM} not found, attempting to create...`);
-        await jsm.streams.add({
-          name: STREAM,
-          subjects: [SUBJECT],
-        });
-      } else {
-        throw err;
+    // Ensure the streams exist
+    const streamsToVerify = [
+      { name: STREAM, subjects: [SUBJECT] },
+      { name: OUTPUT_STREAM, subjects: [OUTPUT_SUBJECT] },
+    ];
+
+    for (const streamCfg of streamsToVerify) {
+      try {
+        await jsm.streams.info(streamCfg.name);
+      } catch (err) {
+        if (err.message.includes('stream not found')) {
+          console.log(
+            `Stream ${streamCfg.name} not found, attempting to create...`,
+          );
+          await jsm.streams.add({
+            name: streamCfg.name,
+            subjects: streamCfg.subjects,
+          });
+        } else {
+          throw err;
+        }
       }
     }
 

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -111,7 +111,11 @@ export async function startWorker(argv = process.argv) {
 
   if (options.dryRun) {
     try {
-      await handleDryRun(options.jobsDir, options.workspacesDir, options.hooksDir);
+      await handleDryRun(
+        options.jobsDir,
+        options.workspacesDir,
+        options.hooksDir,
+      );
     } catch (err) {
       console.error('Dry run failed:', err);
       process.exit(1);
@@ -124,21 +128,24 @@ export async function startWorker(argv = process.argv) {
   const STREAM = options.stream;
   const OUTPUT_STREAM = options.outputStream;
   const SUBJECT = options.inputSubject;
-    const OUTPUT_SUBJECT = options.outputSubject;
-    const JOBS_DIR = options.jobsDir;
-    const WORKSPACES_DIR = options.workspacesDir;
-    const HOOKS_DIR = options.hooksDir;
-    const TIMEOUT_MINUTES = parseInt(options.timeout, 10);
-    const VISIBILITY_TIMEOUT_MS = parseInt(options.visibilityTimeout || '0', 10) * 1000;
-  
-    console.log(`Starting worker ${WORKER_ID} connecting to ${NATS_URL}...`);
-    console.log(`Jobs directory: ${path.resolve(JOBS_DIR)}`);
-    console.log(`Workspaces directory: ${path.resolve(WORKSPACES_DIR)}`);
-    if (HOOKS_DIR) {
-      console.log(`Hooks directory: ${path.resolve(HOOKS_DIR)}`);
-    }
-    console.log(`JetStream Input Stream: ${STREAM}, Subject: ${SUBJECT}`);
-    console.log(`JetStream Output Stream: ${OUTPUT_STREAM}, Subject: ${OUTPUT_SUBJECT}`);
+  const OUTPUT_SUBJECT = options.outputSubject;
+  const JOBS_DIR = options.jobsDir;
+  const WORKSPACES_DIR = options.workspacesDir;
+  const HOOKS_DIR = options.hooksDir;
+  const TIMEOUT_MINUTES = parseInt(options.timeout, 10);
+  const VISIBILITY_TIMEOUT_MS =
+    parseInt(options.visibilityTimeout || '0', 10) * 1000;
+
+  console.log(`Starting worker ${WORKER_ID} connecting to ${NATS_URL}...`);
+  console.log(`Jobs directory: ${path.resolve(JOBS_DIR)}`);
+  console.log(`Workspaces directory: ${path.resolve(WORKSPACES_DIR)}`);
+  if (HOOKS_DIR) {
+    console.log(`Hooks directory: ${path.resolve(HOOKS_DIR)}`);
+  }
+  console.log(`JetStream Input Stream: ${STREAM}, Subject: ${SUBJECT}`);
+  console.log(
+    `JetStream Output Stream: ${OUTPUT_STREAM}, Subject: ${OUTPUT_SUBJECT}`,
+  );
   if (VISIBILITY_TIMEOUT_MS > 0) {
     console.log(
       `Visibility timeout configured: ${VISIBILITY_TIMEOUT_MS / 1000}s`,
@@ -275,7 +282,10 @@ export async function startWorker(argv = process.argv) {
         }
 
         await nc.publish(OUTPUT_SUBJECT, jc.encode(resultPayload));
-        console.log(`Result for job ${id} published to ${OUTPUT_SUBJECT}:`, JSON.stringify(resultPayload));
+        console.log(
+          `Result for job ${id} published to ${OUTPUT_SUBJECT}:`,
+          JSON.stringify(resultPayload),
+        );
 
         await m.ack();
         console.log('Message acknowledged. Disconnecting and exiting...');

--- a/tasks/done/separate-nats-streams.md
+++ b/tasks/done/separate-nats-streams.md
@@ -1,0 +1,26 @@
+# Task: Separate NATS Input and Output Streams
+
+## Description
+Updated the worker to use separate NATS JetStream streams for input and output, improving isolation and reliability in shared NATS environments.
+
+## Changes
+
+### `src/lib/worker.js`
+- Changed default input stream from `JOBS` to `AGENT_JOBS`.
+- Added a new `AGENT_RESULTS` output stream (configurable via `--output-stream` or `NATS_OUTPUT_STREAM`).
+- Refactored startup logic to ensure both streams exist and are correctly configured with their respective subjects.
+- Enhanced logging to show both input and output stream details.
+
+### `README.md`
+- Updated the configuration table to reflect the new defaults and the additional output stream option.
+- Updated examples to use the new stream names.
+
+### `tests/worker.test.js`
+- Added environment variable stub for `NATS_OUTPUT_STREAM`.
+- Added test cases to verify the automatic creation of both input and output streams when they are missing.
+- Updated existing tests to handle the dual-stream verification process.
+
+## Verification Results
+- All 25 unit tests passed (`npm test`).
+- Verified CLI argument parsing and environment variable overrides for both streams.
+- Verified idempotent stream creation logic.

--- a/tests/executor.test.js
+++ b/tests/executor.test.js
@@ -35,7 +35,15 @@ describe('executeJob (Managed Workspace)', () => {
       JSON.stringify(jobConfig),
     );
 
-    const result = await executeJob(jobsRoot, workspacesRoot, jobId, null, null, null, { maxAttempts: 1, delay: 0 });
+    const result = await executeJob(
+      jobsRoot,
+      workspacesRoot,
+      jobId,
+      null,
+      null,
+      null,
+      { maxAttempts: 1, delay: 0 },
+    );
 
     expect(result.status).toBe('success');
     expect(result.exitCode).toBe(0);
@@ -66,7 +74,15 @@ describe('executeJob (Managed Workspace)', () => {
     const sourceDir = path.join(jobsRoot, jobId);
     fs.mkdirSync(sourceDir, { recursive: true });
 
-    const result = await executeJob(jobsRoot, workspacesRoot, jobId, null, null, null, { maxAttempts: 1, delay: 0 });
+    const result = await executeJob(
+      jobsRoot,
+      workspacesRoot,
+      jobId,
+      null,
+      null,
+      null,
+      { maxAttempts: 1, delay: 0 },
+    );
     expect(result.status).toBe('failed');
     expect(result.exitCode).toBe(1);
 
@@ -118,12 +134,15 @@ describe('executeJob (Managed Workspace)', () => {
     // Create a mock post-sync hook
     const hookPath = path.join(hooksDir, 'post-sync');
     const markerPath = path.join(os.tmpdir(), `hook-marker-${Date.now()}`);
-    
+
     // Create a script that writes to a marker file so we can verify execution
     fs.writeFileSync(hookPath, `#!/bin/bash\necho $JOB_ID > ${markerPath}`);
     fs.chmodSync(hookPath, '755');
 
-    await executeJob(jobsRoot, workspacesRoot, jobId, null, null, hooksDir, { maxAttempts: 1, delay: 0 });
+    await executeJob(jobsRoot, workspacesRoot, jobId, null, null, hooksDir, {
+      maxAttempts: 1,
+      delay: 0,
+    });
 
     expect(fs.existsSync(markerPath)).toBe(true);
     expect(fs.readFileSync(markerPath, 'utf8').trim()).toBe(jobId);

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -256,7 +256,7 @@ describe('Worker', () => {
 
   it('should wait for visibility timeout before publishing', async () => {
     vi.mocked(executeJob).mockResolvedValue({ status: 'success', exitCode: 0 });
-    
+
     const mockMsg = {
       data: Buffer.from(JSON.stringify({ id: 'job-delay' })),
       ack: vi.fn().mockResolvedValue(undefined),

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -31,6 +31,7 @@ describe('Worker', () => {
     vi.stubEnv('NATS_USERNAME', 'test-user');
     vi.stubEnv('NATS_PASSWORD', 'test-pass');
     vi.stubEnv('NATS_STREAM', 'TEST_STREAM');
+    vi.stubEnv('NATS_OUTPUT_STREAM', 'TEST_OUTPUT_STREAM');
     vi.stubEnv('NATS_INPUT_SUBJECT', 'test.jobs');
     vi.stubEnv('NATS_OUTPUT_SUBJECT', 'test.results');
     vi.stubEnv('NATS_JOBS_DIR', './test-jobs');
@@ -127,6 +128,25 @@ describe('Worker', () => {
     );
   });
 
+  it('should create output stream if it does not exist', async () => {
+    mockConsumer.fetch.mockResolvedValue(emptyGenerator());
+    const jsm = await mockNC.jetstreamManager();
+    jsm.streams.info.mockImplementation((name) => {
+      if (name === 'TEST_OUTPUT_STREAM') {
+        return Promise.reject(new Error('stream not found'));
+      }
+      return Promise.resolve({});
+    });
+
+    await startWorker(['node', 'worker.js']);
+
+    expect(jsm.streams.info).toHaveBeenCalledWith('TEST_OUTPUT_STREAM');
+    expect(jsm.streams.add).toHaveBeenCalledWith({
+      name: 'TEST_OUTPUT_STREAM',
+      subjects: ['test.results'],
+    });
+  });
+
   it('should create consumer if it does not exist', async () => {
     mockConsumer.fetch.mockResolvedValue(emptyGenerator());
     mockJS.consumers.get.mockRejectedValue(new Error('consumer not found'));
@@ -143,10 +163,15 @@ describe('Worker', () => {
     });
   });
 
-  it('should create stream if it does not exist', async () => {
+  it('should create input stream if it does not exist', async () => {
     mockConsumer.fetch.mockResolvedValue(emptyGenerator());
     const jsm = await mockNC.jetstreamManager();
-    jsm.streams.info.mockRejectedValue(new Error('stream not found'));
+    jsm.streams.info.mockImplementation((name) => {
+      if (name === 'TEST_STREAM') {
+        return Promise.reject(new Error('stream not found'));
+      }
+      return Promise.resolve({});
+    });
 
     await startWorker(['node', 'worker.js']);
 


### PR DESCRIPTION
This change updates the NATS JetStream Job Worker to use separate streams for jobs and results by default. It introduces a new `--output-stream` configuration option and ensures that both the input and output streams are automatically created if they don't exist, preventing potential subject overlap issues in shared NATS environments.

Fixes #36

---
*PR created automatically by Jules for task [15705613696667196735](https://jules.google.com/task/15705613696667196735) started by @boxheed*